### PR TITLE
add codecoverage for sonar (non-breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0]
+
+- Add codecoverage
+
 ## [5.0.0]
 
 - Changed base container to dotnet 5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN mkdir -p ~/scripts
 COPY scripts /scripts
 RUN echo "source /scripts/dotnetcore.sh" >> ~/.bashrc
 
+# install reportgenerator for code coverage
+RUN dotnet tool install -g dotnet-reportgenerator-globaltool
+
 # add entrypoint and run
 COPY dotnet-build.sh /dotnet-build.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/dotnet-build.sh
+++ b/dotnet-build.sh
@@ -69,8 +69,11 @@ echo "running tests"
 for f in *.Test/*.csproj
 do
   echo "Processing $f file..."
-  dotnet test "$f" --no-restore -c $RELEASE -r "$DIST/test-results"  
+  dotnet test "$f" -c $RELEASE -r "$DIST/test-results" /p:CollectCoverage=true /p:CoverletOutputFormat="opencover" /p:CoverletOutput="$DIST/test-coverlet" 
 done
+
+# collect codecoverage files and generate report for sonarcloud (warning is for backwards compatability)
+reportgenerator -reports:"**/*.opencover*.xml" -targetdir:"$DIST/coverage" -reporttypes:"Cobertura;HTMLInline;HTMLChart;SonarQube" || echo -e "\033[33mWARNING: codecoverage not succesfull\033[0m"
 
 # publish
 echo "publishing $CS_PROJECT_FILE"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dotnet-build",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "[![logo](./logo.jpg)](https://inforit.nl)",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Attempt 2 for codecoverage, this time non-breaking:

1. Added report generater tool to docker image
2. Collect the coverage results from the tests
3. Try to generate sonarqube.xml, but don't fail for compatability
