### PR TITLE
Bump .NET sdk version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.400-bullseye-slim-amd64
+FROM mcr.microsoft.com/dotnet/sdk:6.0.401-bullseye-slim-amd64
 
 # install base software
 RUN mkdir -p /usr/share/man/man1 \

--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@ Docker image to automate dotnet builds
 
 ## Instructions
 
-1. update dockerfile
+1. update dockerfile, and version number in package.json
 2. build local version:
 
-    ```sh
-    docker build -t inforitnl/dotnet-build .
-    ```
+   ```sh
+   docker build -t inforitnl/dotnet-build .
+   ```
 
 3. push new version to dockerhub:
 
-    ```sh
-    docker push inforitnl/dotnet-build
-    ```
+   ```sh
+   docker push inforitnl/dotnet-build
+   ```
 
 4. tag and push again (optional but recommended):
 
-    ```sh
-    docker tag inforitnl/dotnet-build inforitnl/dotnet-build:1
-    docker push inforitnl/dotnet-build:1
-    ```
+   ```sh
+   docker tag inforitnl/dotnet-build inforitnl/dotnet-build:1
+   docker push inforitnl/dotnet-build:1
+   ```
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-build",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "[![logo](./logo.jpg)](https://inforit.nl)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Attempting** to bump MSBuild version to 17.3, to fix incorrect 'ambiguous reference' build errors.