### PR TITLE
Changed default `csproj` location to `src` sub folder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.0]
+
+### Breaking changes
+
+- Changed default `csproj` location to `src` sub folder (`./src/Api/Api.csproj`).
+
 ## [8.0.0]
 
 - Updated to NET 7

--- a/dotnet-build.sh
+++ b/dotnet-build.sh
@@ -26,7 +26,7 @@ if [ -n "$MYGET_ACCESS_TOKEN" ]; then
   fi
 fi
 
-CS_PROJECT_FILE="Api/Api.csproj"
+CS_PROJECT_FILE="src/Api/Api.csproj"
 CS_PROJECT_NAME="Api"
 DIST="./dist"
 RELEASE="Release"
@@ -36,7 +36,7 @@ if [ -n "$PROJECT_NAME" ]; then
   CS_PROJECT_NAME="$PROJECT_NAME"
 fi
 
-# change project file location from default "Api.csproj" if specified
+# change project file location from default "src/Api/Api.csproj" if specified
 if [ -n "$PROJECT_FILE" ]; then
   CS_PROJECT_FILE="$PROJECT_FILE"
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-build",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "[![logo](./logo.jpg)](https://inforit.nl)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As we moved the location of our source code into a `src` parent folder I've updated the build container to change the default location.