### PR TITLE
Fix/nuget removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.1.0]
+
+- container now explicitly installs nuget by default
+
 ## [9.0.0]
 
 - Updated various internally used packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /usr/share/man/man1 \
   ca-certificates \
   && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
   && apt-get install --no-install-recommends -y nodejs \
-  && apt-get install -y --no-install-recommends libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb procps\
+  && apt-get install -y --no-install-recommends nuget libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb procps\
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install modern version of java

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-build",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "[![logo](./logo.jpg)](https://inforit.nl)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I added nuget into the list of installed apps so that it is now always installed and creates the nuget directories that the build script needs.

You can already test it with `inforitnl/dotnet-build:9.1.0-beta1`

